### PR TITLE
Added `onRequestClose` prop that would trigger `hideTopModal` by default

### DIFF
--- a/src/modal-controller.tsx
+++ b/src/modal-controller.tsx
@@ -216,6 +216,7 @@ const ModalControllerProvider = (props: ModalControllerProviderProps) => {
             "landscape"
           ]
         }
+        onRequestClose={hideTopModal}
       >
         <TouchableWithoutFeedback
           onPress={isCancelable ? hideTopModal : undefined}


### PR DESCRIPTION
Is there a reason why this functionality wasn't included by default? I'm developing on android and it's natural for me to press the hardware back button when I encounter modals.

Thanks!