### PR TITLE
Support for custom backgroundColor in the backdrop config

### DIFF
--- a/src/modal-controller.tsx
+++ b/src/modal-controller.tsx
@@ -30,6 +30,7 @@ import {
 
 const defaultBackdrop: Required<BackdropConfig> = {
   activeOpacity: 0.5,
+  backgroundColor: 'black',
   transitionInTiming: 500,
   transitionOutTiming: 500
 };
@@ -103,23 +104,20 @@ const ModalAnimator = (props: ModalAnimatorProps) => {
   );
 };
 
-const modalControllerProviderStyles = StyleSheet.create({
-  backdrop: {
-    ...StyleSheet.absoluteFillObject,
-    backgroundColor: "black"
-  }
-});
-
 const ModalControllerProvider = (props: ModalControllerProviderProps) => {
   const [modals, setModals] = useState<ModalType[]>([]);
   const backdropOpacity = useRef(new Animated.Value(0));
 
-  const handleBackdropFade = useCallback(() => {
-    const visibleModals = modals.filter(({ isVisible }) => isVisible);
-    const backdrop = {
+  const backdropConfig = () => {
+    return  {
       ...defaultBackdrop,
       ...(props.backdrop || {})
     };
+  };
+
+  const handleBackdropFade = useCallback(() => {
+    const visibleModals = modals.filter(({ isVisible }) => isVisible);
+    const backdrop = backdropConfig()
     // hide backdrop if the is no modals to display
     if (!visibleModals.length) {
       Animated.timing(backdropOpacity.current, {
@@ -195,6 +193,16 @@ const ModalControllerProvider = (props: ModalControllerProviderProps) => {
     onShowModal: handleShowModal
   };
 
+  const modalControllerProviderStyles = () => { 
+    const backdrop = backdropConfig()
+    return StyleSheet.create({
+      backdrop: {
+        ...StyleSheet.absoluteFillObject,
+        backgroundColor: backdrop.backgroundColor
+      }
+    });
+  };
+
   return (
     <Context.Provider value={modalConsumerProps}>
       {props.children}
@@ -223,7 +231,7 @@ const ModalControllerProvider = (props: ModalControllerProviderProps) => {
         >
           <Animated.View
             style={[
-              modalControllerProviderStyles.backdrop,
+              modalControllerProviderStyles().backdrop,
               { opacity: backdropOpacity.current }
             ]}
           />

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,6 +25,7 @@ export interface BackdropConfig {
   activeOpacity?: number;
   transitionInTiming?: number;
   transitionOutTiming?: number;
+  backgroundColor?: string;
 }
 
 export interface ModalType {


### PR DESCRIPTION
Added support for a custom background color on the modal. The default black color doesn't work with all designs that might wish to use it.

As implemented, the color (as with the other config variables) can be configured by the props on the modal dynamically as needed.